### PR TITLE
Fix aws-sdk version incompatibility and support custom json

### DIFF
--- a/lib/opsworks/deploy/deploy.rb
+++ b/lib/opsworks/deploy/deploy.rb
@@ -2,14 +2,14 @@ require "opsworks/deploy/version"
 require 'aws-sdk'
 
 module Opsworks::Deploy
-  
-  require 'opsworks/deploy/railtie' if defined?(Rails)    
+
+  require 'opsworks/deploy/railtie' if defined?(Rails)
 
   def self.wait_on_deployment(deployment)
     deployment_id = deployment.data[:deployment_id]
     while true
       deployment_desc = AWS.ops_works.client.describe_deployments(deployment_ids: [deployment_id])
-      
+
       status = deployment_desc.data[:deployments].first[:status]
 
       case status
@@ -40,7 +40,7 @@ module Opsworks::Deploy
   end
 
   def self.get_stack(env=nil)
-    
+
     # First try to get from env, then stack files
     if !ENV['STACK_ID'].nil? && !ENV['APP_ID'].nil?
       return {stack_id: ENV['STACK_ID'], app_id: ENV['APP_ID']}

--- a/lib/opsworks/deploy/deploy.rb
+++ b/lib/opsworks/deploy/deploy.rb
@@ -25,6 +25,7 @@ module Opsworks::Deploy
   end
 
   def self.deploy(opts={})
+    Opsworks::Deploy.configure_aws!
     Deployment.new(opts).deploy
   end
 
@@ -38,8 +39,6 @@ module Opsworks::Deploy
         env: nil
       }.merge(options)
       @client = client
-
-      Opsworks::Deploy.configure_aws!
     end
 
     def deploy

--- a/lib/opsworks/deploy/deploy.rb
+++ b/lib/opsworks/deploy/deploy.rb
@@ -21,10 +21,7 @@ module Opsworks::Deploy
     raise ArgumentError, "Must set IAM_KEY environment variable" if iam_key.nil? || iam_key.length == 0
     raise ArgumentError, "Must set IAM_SECRET environment variable" if iam_secret.nil? || iam_secret.length == 0
 
-    AWS.config({
-      access_key_id: iam_key,
-      secret_access_key: iam_secret,
-    })
+    AWS.config(access_key_id: iam_key, secret_access_key: iam_secret)
   end
 
   def self.deploy(opts={})

--- a/lib/opsworks/deploy/deploy.rb
+++ b/lib/opsworks/deploy/deploy.rb
@@ -43,7 +43,7 @@ module Opsworks::Deploy
 
     # First try to get from env, then stack files
     if !ENV['STACK_ID'].nil? && !ENV['APP_ID'].nil?
-      return {stack_id: ENV['STACK_ID'], app_id: ENV['APP_ID']}
+      return {'stack_id' => ENV['STACK_ID'], 'app_id' => ENV['APP_ID']}
     elsif stacks = get_config_stacks
       raise "Missing stacks configuration for #{env} in stacks.json" if stacks[env].nil?
 

--- a/lib/opsworks/deploy/deploy.rb
+++ b/lib/opsworks/deploy/deploy.rb
@@ -59,7 +59,7 @@ module Opsworks::Deploy
         env: nil
       }.merge(options)
 
-      Opsworks::Deploy.configure_aws! # Ensure we are properly configured
+      Opsworks::Deploy.configure_aws!
     end
 
     def deploy
@@ -77,11 +77,21 @@ module Opsworks::Deploy
         stack_id: configuration['stack_id'],
         app_id: configuration['app_id'],
         command: command
-      }
+      }.tap do |args|
+        args[:custom_json] = custom_json if custom_json?
+      end
     end
 
     def command
       {name: 'deploy', args: {'migrate' => [options[:migrate] ? 'true' : 'false']}}
+    end
+
+    def custom_json
+      configuration['custom_json'].to_json
+    end
+
+    def custom_json?
+      configuration.has_key?('custom_json')
     end
 
     def configuration

--- a/lib/opsworks/deploy/deploy.rb
+++ b/lib/opsworks/deploy/deploy.rb
@@ -7,8 +7,6 @@ module Opsworks::Deploy
 
   def self.wait_on_deployment(deployment)
     deployment_id = deployment.data[:deployment_id]
-    deployment_desc = nil
-
     while true
       deployment_desc = AWS.ops_works.client.describe_deployments(deployment_ids: [deployment_id])
       
@@ -23,8 +21,6 @@ module Opsworks::Deploy
         raise "Failed to run deployment: #{deployment_id} - #{status}"
       end
     end
-
-    return true if deployment_desc.data[:status] == 'successful'
   end
 
   # Look for config/stacks.json or stacks.json

--- a/opsworks-deploy.gemspec
+++ b/opsworks-deploy.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency 'aws-sdk'
+  spec.add_runtime_dependency 'aws-sdk', '~> 1.62'
   spec.add_runtime_dependency 'json'
 
   spec.add_development_dependency "bundler", "~> 1.3"

--- a/opsworks-deploy.gemspec
+++ b/opsworks-deploy.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |spec|
   spec.authors       = ["Geoff Hayes"]
   spec.email         = ["hayesgm@gmail.com"]
   spec.description   = %q{Quick and easy rake task for deploying to AWS OpsWorks}
-  spec.summary       = %q{A quick rake task that will deploy to AWS OpsWorks.  This can be added as a post-step in Continuous Integration.  `rake opsworks:deply`}
+  spec.summary       = %q{A quick rake task that will deploy to AWS OpsWorks.  This can be added as a post-step in Continuous Integration.  `rake opsworks:deploy`}
   spec.homepage      = "https://github.com/hayesgm/opsworks-deploy"
   spec.license       = "MIT"
 

--- a/spec/opsworks_deploy_spec.rb
+++ b/spec/opsworks_deploy_spec.rb
@@ -46,7 +46,7 @@ describe 'opsworks:deploy rake task' do
       ENV['IAM_KEY'] = ENV['IAM_SECRET'] = "a"
 
       # Allow file config
-      expect(File).to receive(:exists?).and_return(true)
+      allow(Dir).to receive(:[]).and_return(['config/stacks.json'])
       expect(File).to receive(:read).and_return(config.to_json)
 
       expected_params = { stack_id: "sid", app_id: "aid", command: {name: 'deploy', args: {"migrate" => [ "false" ] } } }
@@ -81,7 +81,7 @@ describe 'opsworks:deploy rake task' do
       ENV['IAM_KEY'] = ENV['IAM_SECRET'] = "a"
 
       # Allow file config
-      expect(File).to receive(:exists?).and_return(true)
+      allow(Dir).to receive(:[]).and_return(['config/stacks.json'])
       expect(File).to receive(:read).and_return(config.to_json)
 
       expected_params = { stack_id: "sid", app_id: "aid", command: {name: 'deploy', args: {"migrate" => [ "true" ] } } }


### PR DESCRIPTION
This gem uses the constant `AWS`, which is only present in the aws-sdk version 1.

I refactored a bit to make things easier to extend and then added the option of custom JSON. I need this for a Postgres-backed deployment.
